### PR TITLE
Add implicit ReactiveCocoa Dependencies

### DIFF
--- a/RomeReactiveCocoaTest/AppDelegate.swift
+++ b/RomeReactiveCocoaTest/AppDelegate.swift
@@ -6,6 +6,11 @@
 //  Copyright © 2017 Perfectly-Cooked. All rights reserved.
 //
 
+/// Implicit ReactiveCocoa Dependencies
+
+import CoreLocation
+import MapKit
+
 import UIKit
 
 @UIApplicationMain


### PR DESCRIPTION
Implicit dependencies of frameworks when using binaries are not copied over by Xcode automatically despite "Always Embed Standard Libraries" set to YES.

If you explicitly declare a dependency then they are.

In this case, these are RecativeCocoa dependencies.
